### PR TITLE
Richer definition for contract ABI

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare module 'web3' {
             sign(address: string, message: string, callback: (err: Error, signData: string) => void): string;
             getBlock(blockHash: string, callback: (err: Error, blockObj: any) => void): BigNumber.BigNumber;
             getBlockNumber(callback: (err: Error, blockNumber: number) => void): void;
-            contract(abi: Web3.AbiDefinition[]): Web3.Contract;
+            contract<A>(abi: Web3.ContractAbi): Web3.Contract<A>;
             getBalance(addressHexString: string,
                 callback?: (err: any, result: BigNumber.BigNumber) => void): BigNumber.BigNumber;
             getCode(addressHexString: string,
@@ -44,21 +44,39 @@ declare module 'web3' {
     }
 
     namespace Web3 {
-        interface AbiIOParameter {
+        type ContractAbi = Array<AbiDefinition>;
+
+        type AbiDefinition = FunctionDescription | EventDescription;
+
+        interface FunctionDescription {
+            type: "function" | "constructor" | "fallback";
+            name: string;
+            inputs: Array<FunctionParameter>;
+            outputs?: Array<FunctionParameter>;
+            constant: boolean;
+            payable: boolean;
+        }
+
+        interface EventParameter {
+            name: string;
+            type: string;
+            indexed: boolean;
+        }
+
+        interface EventDescription {
+            type: "event";
+            name: string;
+            inputs: Array<EventParameter>;
+            anonymous: boolean;
+        }
+
+        interface FunctionParameter {
             name: string;
             type: string;
         }
 
-        interface AbiDefinition {
-            constants: boolean;
-            inputs: AbiIOParameter[];
-            name: string;
-            outputs: AbiIOParameter[];
-            type: string;
-        }
-
-        interface Contract {
-            at(address: string): ContractInstance;
+        interface Contract<A> {
+            at(address: string): A;
         }
 
         interface FilterObject {
@@ -79,8 +97,6 @@ declare module 'web3' {
             watch<A>(callback: (error: string|null, result: SolidityEvent<A>) => void): void;
             stopWatching(callback: () => void): void;
         }
-
-        interface ContractInstance {}
 
         interface Provider {}
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,11 +50,11 @@ declare module 'web3' {
 
         interface FunctionDescription {
             type: "function" | "constructor" | "fallback";
-            name: string;
+            name?: string;
             inputs: Array<FunctionParameter>;
             outputs?: Array<FunctionParameter>;
-            constant: boolean;
-            payable: boolean;
+            constant?: boolean;
+            payable?: boolean;
         }
 
         interface EventParameter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,9 +68,15 @@ declare module 'web3' {
             topics: string[];
         }
 
+        interface SolidityEvent<A> {
+            event: string
+            address: string
+            args: A
+        }
+
         interface FilterResult {
             get(callback: () => void): void;
-            watch(callback: () => void): void;
+            watch<A>(callback: (error: string|null, result: SolidityEvent<A>) => void): void;
             stopWatching(): void;
         }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ declare module 'web3' {
         interface FilterResult {
             get(callback: () => void): void;
             watch<A>(callback: (error: string|null, result: SolidityEvent<A>) => void): void;
-            stopWatching(): void;
+            stopWatching(callback: () => void): void;
         }
 
         interface ContractInstance {}


### PR DESCRIPTION
Make web3 typings useable for interacting with a deployed contract in a type safe way.