### PR TITLE
Provided a better deprecation warning

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -120,12 +120,16 @@ declare module 'web3' {
             args: A;
         }
 
+        /**
+         * @deprecated Use {@link DecodedLogEntry<A>}
+         */
         interface DecodedLogEntryEvent<A> extends DecodedLogEntry<A> {
-            removed: boolean;
         }
 
+        /**
+         * @deprecated Use {@link LogEntry}
+         */
         interface LogEntryEvent extends LogEntry {
-            removed: boolean;
         }
 
         interface FilterResult {


### PR DESCRIPTION
JSDoc is parsed by TSLint and thus will warn during linting when
using @deprecated block, while the "removed" property will
silently fail