### PR TITLE
Made the callback in filter.stopWatching optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -131,7 +131,7 @@ declare module 'web3' {
         interface FilterResult {
             get(callback: () => void): void;
             watch(callback: (err: Error, result: LogEntryEvent) => void): void;
-            stopWatching(callback: () => void): void;
+            stopWatching(callback?: () => void): void;
         }
 
         export interface JSONRPCRequestPayload {


### PR DESCRIPTION
The callback is optional by design, and the function works without it