### PR TITLE
Fix ContractInstance new() not parsing properly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -103,7 +103,7 @@ declare module 'web3' {
 
         interface Contract<A extends ContractInstance> {
             at(address: string): A;
-            new(...args: any[]): A;
+            'new'(...args: any[]): A;
         }
 
         interface FilterObject {


### PR DESCRIPTION
new is a keyword in typescript and so if a function is called new(),
tsc and for example Visual Studio Code don't regonize types for this
function. The fix is to write this function in quotes