### PR TITLE
Added stateMutability to ABIs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,12 +57,16 @@ declare module 'web3' {
             Fallback = 'fallback',
         }
 
+        type ConstructorStateMutability = 'nonpayable' | 'payable';
+        type StateMutability = 'pure' | 'view' | ConstructorStateMutability;
+
         interface MethodAbi {
             type: AbiType.Function;
             name: string;
             inputs: FunctionParameter[];
             outputs: FunctionParameter[];
             constant: boolean;
+            stateMutability: StateMutability;
             payable: boolean;
         }
 
@@ -70,6 +74,7 @@ declare module 'web3' {
             type: AbiType.Constructor;
             inputs: FunctionParameter[];
             payable: boolean;
+            stateMutability: ConstructorStateMutability;
         }
 
         interface FallbackAbi {


### PR DESCRIPTION
In the newest version of Solidity, additional property was added,
called state mutability, specyfing what kind of access does the
function have to memory and storage.
Additionally, constructor mutability is limited to payable/non-payable
as it HAS to modify the storage to actually deploy the contract