### PR TITLE
Typify Contract<T>.getData

### DIFF
--- a/web3/index.d.ts
+++ b/web3/index.d.ts
@@ -108,6 +108,7 @@ declare module 'web3' {
 
         interface Contract<A extends ContractInstance> {
             at(address: string): A;
+            getData(...args: any[]): string;
             'new'(...args: any[]): A;
         }
 


### PR DESCRIPTION
Pretty self-explanatory. This method is used to get the constructor bytecode data of a contract to be deployed with given parameters. Useful for gas estimation and whatnot.