### PR TITLE
Fix bug for filter.get method

### DIFF
--- a/web3/index.d.ts
+++ b/web3/index.d.ts
@@ -134,7 +134,7 @@ declare module 'web3' {
         }
 
         interface FilterResult {
-            get(callback: () => void): void;
+            get(callback: (err: Error, result: any) => void): void;
             watch(callback: (err: Error, result: LogEntryEvent) => void): void;
             stopWatching(callback?: () => void): void;
         }


### PR DESCRIPTION
For compilation error, `TS2345: Argument of type '(err: any, result: any) => void' is not assignable to parameter of type '() => void'`